### PR TITLE
Fix setup to run on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ Makefile
 /doc
 /.config
 /InstalledFiles
+.source_index
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
- rvm:
-   - 1.8.7
-   - 1.9.2
-   - 1.9.3
-   - rbx
-   - ree
+script: ./run_tests
+rvm:
+  - 1.8.7
+  - 1.9.2
+  - 1.9.3
+  - rbx-18mode
+  - rbx-19mode
+  - ree
+matrix:
+  allow_failures:
+    - rvm rbx-18mode
+    - rvm rbx-19mode

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source :rubygems
+
+gem 'rake', '0.9.3'
+gem 'hoe'
+gem 'rack'

--- a/run_tests
+++ b/run_tests
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+ruby setup.rb
+bundle exec rake test


### PR DESCRIPTION
In support of rubinius/rubinius#2006 I wanted to get the tests working.

Adding the Gemfile was the easiest way to install the deps.

Once I added the `run_tests` script I could get the tests to run on [Travis](https://travis-ci.org/jc00ke/fast_xs/builds/3169204). At least they fail now from tests and not from a `LoadError` when trying to `require 'hoe'`.
