### PR TITLE
Minor grammar fixes to README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -23,8 +23,8 @@ Ruby on Rails will automatically use String#fast_xs from either Hpricot
 or this gem version with the bundled Builder package.
 
 String#fast_xs is an almost exact translation of Sam Ruby's original
-implementation (String#to_xs), but it does escape "&quot;" (which is an
-optional, but all parsers are able ot handle it.  XML::Builder as
+implementation (String#to_xs), but it does escape "&quot;" (which is
+optional, but all parsers are able to handle it).  XML::Builder as
 packaged in Rails 2.0 will be automatically use String#fast_xs instead
 of String#to_xs available.
 


### PR DESCRIPTION
add missing paren, remove stray "an", fix "ot" -> "to"
