### PR TITLE
Fix incompatible-pointer-types error during build

### DIFF
--- a/ext/fast_xs/fast_xs.c
+++ b/ext/fast_xs/fast_xs.c
@@ -125,7 +125,7 @@ static VALUE unpack_utf8(VALUE self)
 	return rb_funcall(self, unpack_id, 1, U_fmt);
 }
 
-static VALUE unpack_uchar(VALUE self)
+static VALUE unpack_uchar(VALUE self, VALUE error)
 {
 	return rb_funcall(self, unpack_id, 1, C_fmt);
 }


### PR DESCRIPTION
Fixes issue #8 

Before:
```
❯ make
-e:1:in `<main>': uninitialized constant Config (NameError)

puts Config::CONFIG["DLEXT"]
     ^^^^^^
Did you mean?  RbConfig
/Library/Developer/CommandLineTools/usr/bin/make test/test_cgi_class_overrides.rb test/test_erb_util_module_overrides.rb test/test_mongrel_overrides.rb test/test_rack_util_overrides.rb test/test_xml_escaping.rb
-e:1:in `<main>': uninitialized constant Config (NameError)

puts Config::CONFIG["DLEXT"]
     ^^^^^^
Did you mean?  RbConfig
cd ext/fast_xs && ruby extconf.rb
checking for assert.h... yes
creating Makefile
/Library/Developer/CommandLineTools/usr/bin/make -C ext/fast_xs
compiling fast_xs.c
fast_xs.c:146:39: error: incompatible function pointer types passing 'VALUE (VALUE)' (aka 'unsigned long (unsigned long)') to parameter of type 'VALUE (*)(VALUE, VALUE)' (aka 'unsigned long (*)(unsigned long, unsigned long)') [-Wincompatible-function-pointer-types]
        array = rb_rescue(unpack_utf8, self, unpack_uchar, self);
                                             ^~~~~~~~~~~~
/Users/spozder/.rubies/ruby-3.1.5/include/ruby-3.1.0/ruby/internal/iterator.h:364:62: note: passing argument to parameter 'r_proc' here
VALUE rb_rescue(VALUE (*b_proc)(VALUE), VALUE data1, VALUE (*r_proc)(VALUE, VALUE), VALUE data2);
                                                             ^
1 error generated.
make[2]: *** [fast_xs.o] Error 1
make[1]: *** [ext/fast_xs/fast_xs.] Error 2
make: *** [test] Error 2
```

After:
```
❯ make
-e:1:in `<main>': uninitialized constant Config (NameError)

puts Config::CONFIG["DLEXT"]
     ^^^^^^
Did you mean?  RbConfig
/Library/Developer/CommandLineTools/usr/bin/make test/test_cgi_class_overrides.rb test/test_erb_util_module_overrides.rb test/test_mongrel_overrides.rb test/test_rack_util_overrides.rb test/test_xml_escaping.rb
-e:1:in `<main>': uninitialized constant Config (NameError)

puts Config::CONFIG["DLEXT"]
     ^^^^^^
Did you mean?  RbConfig
/Library/Developer/CommandLineTools/usr/bin/make -C ext/fast_xs
compiling fast_xs.c
linking shared-object fast_xs.bundle
ld: warning: ignoring duplicate libraries: '-lruby.3.1'
...
```